### PR TITLE
#6-포스트 삭제 테스트 및 기능 구현

### DIFF
--- a/src/main/java/com/fastcampus/fcsns/controller/PostController.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/PostController.java
@@ -31,5 +31,4 @@ public class PostController {
 
         return Response.success(PostResponse.fromPost(post));
     }
-
 }

--- a/src/main/java/com/fastcampus/fcsns/controller/PostController.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/PostController.java
@@ -31,4 +31,11 @@ public class PostController {
 
         return Response.success(PostResponse.fromPost(post));
     }
+
+    @DeleteMapping("/{postId}")
+    public Response<Void> delete(@PathVariable Integer postId, Authentication authentication) {
+        postService.delete(authentication.getName(), postId);
+
+        return Response.success();
+    }
 }

--- a/src/main/java/com/fastcampus/fcsns/service/PostService.java
+++ b/src/main/java/com/fastcampus/fcsns/service/PostService.java
@@ -47,4 +47,19 @@ public class PostService {
 
         return Post.fromEntity(postEntityRepository.saveAndFlush(postEntity));
     }
+
+    @Transactional
+    public void delete(String userName, Integer postId) {
+        UserEntity userEntity = userEntityRepository.findByUserName(userName).orElseThrow(() ->
+                new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded", userName)));
+
+        PostEntity postEntity = postEntityRepository.findById(postId).orElseThrow(() ->
+                new SnsApplicationException(ErrorCode.POST_NOT_FOUND, String.format("%s not founded", postId)));
+
+        if(postEntity.getUser() != userEntity) {
+            throw new SnsApplicationException(ErrorCode.INVALID_PERMISSION, String.format("%s has no permission with %s", userName, postId));
+        }
+
+        postEntityRepository.delete(postEntity);
+    }
 }


### PR DESCRIPTION
포스트 삭제 테스트를 작성하고, 기능을 구현하였다.

포스트를 삭제할 때에는 deleted_at 컬럼에 삭제한 시간을 업데이트하는 soft delete 방식으로 구현하였다.
그리고 포스트를 조회할 때에는 deleted_at 컬럼이 null인 post만 가져오도록 where 어노테이션에 조건을 지정하였으므로 
삭제된 포스트는 조회 되지 않게 된다.