### PR TITLE
#8-포스트 수정 및 삭제시 오류 수정, 로그인 및 회원가입시 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,8 @@ task cleanFrontEnd(type: Delete) {
 	delete "$projectDir/front-end/static", "$projectDir/front-end/node_modules"
 }
 
-//npmBuild.dependsOn npmInstall
-//copyFrontEnd.dependsOn npmBuild
-//compileJava.dependsOn copyFrontEnd
-//
-//clean.dependsOn cleanFrontEnd
+npmBuild.dependsOn npmInstall
+copyFrontEnd.dependsOn npmBuild
+compileJava.dependsOn copyFrontEnd
+
+clean.dependsOn cleanFrontEnd

--- a/src/main/java/com/fastcampus/fcsns/controller/PostController.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/PostController.java
@@ -28,7 +28,7 @@ public class PostController {
     }
 
     @PutMapping("/{postId}")
-    public Response<PostResponse> modify(@RequestBody PostModifyRequest request, @PathVariable Integer postId, Authentication authentication) {
+    public Response<PostResponse> modify(@PathVariable Integer postId, @RequestBody PostModifyRequest request, Authentication authentication) {
         Post post = postService.modify(request.getTitle(), request.getBody(), authentication.getName(), postId);
 
         return Response.success(PostResponse.fromPost(post));

--- a/src/main/java/com/fastcampus/fcsns/controller/UserController.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/UserController.java
@@ -23,7 +23,7 @@ public class UserController {
     // TODO : implement
     @PostMapping("/join")
     public Response<UserJoinResponse> join(@RequestBody UserJoinRequest request) {
-        User user = userService.join(request.getUserName(), request.getPassword());
+        User user = userService.join(request.getName(), request.getPassword());
         UserJoinResponse response = UserJoinResponse.fromUser(user);
 
         return Response.success(response);
@@ -31,7 +31,7 @@ public class UserController {
 
     @PostMapping("/login")
     public Response<UserLoginResponse> login(@RequestBody UserLoginRequest request) {
-        String token = userService.login(request.getUserName(), request.getPassword());
+        String token = userService.login(request.getName(), request.getPassword());
 
         return Response.success(new UserLoginResponse(token));
     }

--- a/src/main/java/com/fastcampus/fcsns/controller/request/PostModifyRequest.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/request/PostModifyRequest.java
@@ -8,5 +8,4 @@ import lombok.Getter;
 public class PostModifyRequest {
     private String title;
     private String body;
-    private Integer postId;
 }

--- a/src/main/java/com/fastcampus/fcsns/controller/request/UserJoinRequest.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/request/UserJoinRequest.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class UserJoinRequest {
 
-    private String userName;
+    private String name;
     private String password;
 }

--- a/src/main/java/com/fastcampus/fcsns/controller/request/UserLoginRequest.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/request/UserLoginRequest.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class UserLoginRequest {
-    private String userName;
+    private String name;
     private String password;
 }

--- a/src/main/java/com/fastcampus/fcsns/controller/response/PostResponse.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/response/PostResponse.java
@@ -10,7 +10,7 @@ import java.sql.Timestamp;
 @AllArgsConstructor
 public class PostResponse {
 
-    private Integer postId;
+    private Integer id;
 
     private String title;
 
@@ -27,7 +27,7 @@ public class PostResponse {
 
     public static PostResponse fromPost(Post post) {
         return new PostResponse(
-                post.getPostId(),
+                post.getId(),
                 post.getTitle(),
                 post.getBody(),
                 UserResponse.fromUser(post.getUser()),

--- a/src/main/java/com/fastcampus/fcsns/model/Post.java
+++ b/src/main/java/com/fastcampus/fcsns/model/Post.java
@@ -10,7 +10,7 @@ import java.sql.Timestamp;
 @AllArgsConstructor
 public class Post {
 
-    private Integer postId;
+    private Integer id;
 
     private String title;
 

--- a/src/test/java/com/fastcampus/fcsns/controller/PostControllerTest.java
+++ b/src/test/java/com/fastcampus/fcsns/controller/PostControllerTest.java
@@ -88,7 +88,7 @@ public class PostControllerTest {
         // When
         mockMvc.perform(put("/api/v1/posts/" + postId)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsBytes(new PostModifyRequest(title, body, postId)))
+                        .content(objectMapper.writeValueAsBytes(new PostModifyRequest(title, body)))
                 ).andDo(print())
                 .andExpect(status().isOk());
 
@@ -106,7 +106,7 @@ public class PostControllerTest {
         // When
         mockMvc.perform(put("/api/v1/posts/" + postId)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsBytes(new PostModifyRequest(title, body, postId)))
+                        .content(objectMapper.writeValueAsBytes(new PostModifyRequest(title, body)))
                 ).andDo(print())
                 .andExpect(status().isUnauthorized());
     }
@@ -124,7 +124,7 @@ public class PostControllerTest {
 
         mockMvc.perform(put("/api/v1/posts/" + postId)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsBytes(new PostModifyRequest(title, body, postId)))
+                        .content(objectMapper.writeValueAsBytes(new PostModifyRequest(title, body)))
                 ).andDo(print())
                 .andExpect(status().isUnauthorized());
     }
@@ -142,7 +142,7 @@ public class PostControllerTest {
 
         mockMvc.perform(put("/api/v1/posts/" + postId)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsBytes(new PostModifyRequest(title, body, postId)))
+                        .content(objectMapper.writeValueAsBytes(new PostModifyRequest(title, body)))
                 ).andDo(print())
                 .andExpect(status().isNotFound());
 


### PR DESCRIPTION
엔티티를 wrap 해주는 Post 클래스와 응답으로 사용되는 PostResponse 클래스의 아이디 필드명이
프론트엔드에서 사용되는 필드명과 달라 발생한 오류
프론트엔드에서 setter를 사용해 'id'를 가져와 사용하는데, 필드명이 'postId'로 되어있어 이를 찾을 수 없어
콘솔창에서는 'undifined' 로 출력되었다.
프론트엔드에서 사용하는 필드명과 응답으로 사용하는 클래스의 필드명을 일치시켜 이를 해결했다.