### PR TITLE
#10 - 댓글 기능 테스트 작성 및 기능 구현

### DIFF
--- a/src/main/java/com/fastcampus/fcsns/controller/PostController.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/PostController.java
@@ -1,11 +1,12 @@
 package com.fastcampus.fcsns.controller;
 
+import com.fastcampus.fcsns.controller.request.CommentRequest;
 import com.fastcampus.fcsns.controller.request.PostCreateRequest;
 import com.fastcampus.fcsns.controller.request.PostModifyRequest;
+import com.fastcampus.fcsns.controller.response.CommentResponse;
 import com.fastcampus.fcsns.controller.response.PostResponse;
 import com.fastcampus.fcsns.controller.response.Response;
 import com.fastcampus.fcsns.model.Post;
-import com.fastcampus.fcsns.model.entity.PostEntity;
 import com.fastcampus.fcsns.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -67,5 +68,18 @@ public class PostController {
     public Response<Integer> likeCount(@PathVariable Integer postId, Authentication authentication) {
 
         return Response.success(postService.likeCount(postId));
+    }
+
+    @PostMapping("/{postId}/comments")
+    public Response<Void> comment(@PathVariable Integer postId, @RequestBody CommentRequest request, Authentication authentication) {
+        postService.comment(postId, request.getComment(), authentication.getName());
+
+        return Response.success();
+    }
+
+    @GetMapping("{postId}/comments")
+    public Response<Page<CommentResponse>> comment(@PathVariable Integer postId, Pageable pageable, Authentication authentication) {
+        return Response.success(postService.getComments(postId, pageable).map(CommentResponse::fromComment));
+
     }
 }

--- a/src/main/java/com/fastcampus/fcsns/controller/request/CommentRequest.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/request/CommentRequest.java
@@ -1,0 +1,12 @@
+package com.fastcampus.fcsns.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentRequest {
+    private String comment;
+}

--- a/src/main/java/com/fastcampus/fcsns/controller/response/CommentResponse.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/response/CommentResponse.java
@@ -1,0 +1,37 @@
+package com.fastcampus.fcsns.controller.response;
+
+import com.fastcampus.fcsns.model.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+@Getter
+@AllArgsConstructor
+public class CommentResponse {
+    private Integer id;
+
+    private String comment;
+
+    private Integer postId;
+
+    private String userName;
+
+    private Timestamp registeredAt;
+
+    private Timestamp updatedAt;
+
+    private Timestamp deletedAt;
+
+    public static CommentResponse fromComment(Comment comment) {
+        return new CommentResponse(
+                comment.getId(),
+                comment.getComment(),
+                comment.getPostId(),
+                comment.getUserName(),
+                comment.getRegisteredAt(),
+                comment.getUpdatedAt(),
+                comment.getDeleted_at()
+        );
+    }
+}

--- a/src/main/java/com/fastcampus/fcsns/model/Comment.java
+++ b/src/main/java/com/fastcampus/fcsns/model/Comment.java
@@ -1,0 +1,39 @@
+package com.fastcampus.fcsns.model;
+
+import com.fastcampus.fcsns.model.entity.CommentEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+@Getter
+@AllArgsConstructor
+public class Comment {
+    private Integer id;
+
+    private String comment;
+
+    private Integer postId;
+
+    private String userName;
+
+    private Timestamp registeredAt;
+
+    private Timestamp updatedAt;
+
+    private Timestamp deleted_at;
+
+    public static Comment fromEntity(CommentEntity entity) {
+        return new Comment(
+                entity.getId(),
+                entity.getComment(),
+                entity.getPost().getId(),
+                entity.getUser().getUserName(),
+                entity.getRegistered_at(),
+                entity.getUpdated_at(),
+                entity.getDeleted_at()
+        );
+    }
+
+
+}

--- a/src/main/java/com/fastcampus/fcsns/model/entity/CommentEntity.java
+++ b/src/main/java/com/fastcampus/fcsns/model/entity/CommentEntity.java
@@ -1,0 +1,62 @@
+package com.fastcampus.fcsns.model.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+import java.time.Instant;
+
+@Getter
+@Setter
+@Where(clause = "deleted_at is null")
+@SQLDelete(sql = "UPDATE \"comment\" SET deleted_at = now() WHERE id = ?")
+@Table(name = "\"comments\"", indexes = {
+        @Index(name = "post_id_idx", columnList = "post_id")
+})
+@Entity
+public class CommentEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private PostEntity post;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    @Column(name = "comment")
+    private String comment;
+
+    @Column(name = "registered_at")
+    private Timestamp registered_at;
+
+    @Column(name = "updated_at")
+    private Timestamp updated_at;
+
+    @Column(name = "deleted_at")
+    private Timestamp deleted_at;
+
+    @PrePersist
+    void registered_at() { this.registered_at = Timestamp.from(Instant.now()); }
+
+    @PreUpdate
+    void updated_at() { this.updated_at = Timestamp.from(Instant.now()); }
+
+    public static CommentEntity of(UserEntity userEntity, PostEntity postEntity, String comment) {
+        CommentEntity commentEntity = new CommentEntity();
+
+        commentEntity.setUser(userEntity);
+        commentEntity.setPost(postEntity);
+        commentEntity.setComment(comment);
+
+        return commentEntity;
+    }
+
+}

--- a/src/main/java/com/fastcampus/fcsns/repository/CommentEntityRepository.java
+++ b/src/main/java/com/fastcampus/fcsns/repository/CommentEntityRepository.java
@@ -1,0 +1,14 @@
+package com.fastcampus.fcsns.repository;
+
+import com.fastcampus.fcsns.model.entity.CommentEntity;
+import com.fastcampus.fcsns.model.entity.PostEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentEntityRepository extends JpaRepository<CommentEntity, Integer> {
+
+    Page<CommentEntity> findAllByPost(PostEntity post, Pageable pageable);
+}

--- a/src/main/java/com/fastcampus/fcsns/repository/LikeEntityRepository.java
+++ b/src/main/java/com/fastcampus/fcsns/repository/LikeEntityRepository.java
@@ -6,11 +6,12 @@ import com.fastcampus.fcsns.model.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
-
+@Repository
 public interface LikeEntityRepository extends JpaRepository<LikeEntity, Integer> {
 
     Optional<LikeEntity> findByUserAndPost(UserEntity user, PostEntity post);

--- a/src/main/java/com/fastcampus/fcsns/service/PostService.java
+++ b/src/main/java/com/fastcampus/fcsns/service/PostService.java
@@ -2,10 +2,13 @@ package com.fastcampus.fcsns.service;
 
 import com.fastcampus.fcsns.exception.ErrorCode;
 import com.fastcampus.fcsns.exception.SnsApplicationException;
+import com.fastcampus.fcsns.model.Comment;
 import com.fastcampus.fcsns.model.Post;
+import com.fastcampus.fcsns.model.entity.CommentEntity;
 import com.fastcampus.fcsns.model.entity.LikeEntity;
 import com.fastcampus.fcsns.model.entity.PostEntity;
 import com.fastcampus.fcsns.model.entity.UserEntity;
+import com.fastcampus.fcsns.repository.CommentEntityRepository;
 import com.fastcampus.fcsns.repository.LikeEntityRepository;
 import com.fastcampus.fcsns.repository.PostEntityRepository;
 import com.fastcampus.fcsns.repository.UserEntityRepository;
@@ -25,24 +28,21 @@ public class PostService {
     private final UserEntityRepository userEntityRepository;
     private final PostEntityRepository postEntityRepository;
     private final LikeEntityRepository likeEntityRepository;
+    private final CommentEntityRepository commentEntityRepository;
 
     @Transactional
     public void create(String title, String body, String userName) {
 
-        UserEntity userEntity = userEntityRepository.findByUserName(userName).orElseThrow(() ->
-                new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded", userName)));
+        UserEntity userEntity = getUserOrException(userName);
 
         postEntityRepository.save(PostEntity.of(title, body, userEntity));
     }
 
     @Transactional
     public Post modify(String title, String body, String userName, Integer postId) {
-        UserEntity userEntity = userEntityRepository.findByUserName(userName).orElseThrow(() ->
-                new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded", userName)));
+        UserEntity userEntity = getUserOrException(userName);
 
-        // post exists
-        PostEntity postEntity = postEntityRepository.findById(postId).orElseThrow(() ->
-            new SnsApplicationException(ErrorCode.POST_NOT_FOUND, String.format("%s not founded", postId)));
+        PostEntity postEntity = getPostOrException(postId);
 
 
         // post permission
@@ -58,11 +58,9 @@ public class PostService {
 
     @Transactional
     public void delete(String userName, Integer postId) {
-        UserEntity userEntity = userEntityRepository.findByUserName(userName).orElseThrow(() ->
-                new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded", userName)));
+        UserEntity userEntity = getUserOrException(userName);
 
-        PostEntity postEntity = postEntityRepository.findById(postId).orElseThrow(() ->
-                new SnsApplicationException(ErrorCode.POST_NOT_FOUND, String.format("%s not founded", postId)));
+        PostEntity postEntity = getPostOrException(postId);
 
         if(postEntity.getUser() != userEntity) {
             throw new SnsApplicationException(ErrorCode.INVALID_PERMISSION, String.format("%s has no permission with %s", userName, postId));
@@ -76,8 +74,7 @@ public class PostService {
     }
 
     public Page<Post> my(Pageable pageable, String userName) {
-        UserEntity userEntity = userEntityRepository.findByUserName(userName).orElseThrow(() ->
-                new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded", userName)));
+        UserEntity userEntity = getUserOrException(userName);
 
         return postEntityRepository.findAllByUser(userEntity, pageable).map(Post::fromEntity);
     }
@@ -85,10 +82,8 @@ public class PostService {
     @Transactional
     public void likes(Integer postId, String userName) {
 
-        UserEntity userEntity = userEntityRepository.findByUserName(userName).orElseThrow(() ->
-                new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded", userName)));
-        PostEntity postEntity = postEntityRepository.findById(postId).orElseThrow(() ->
-                new SnsApplicationException(ErrorCode.POST_NOT_FOUND, String.format("%s not founded", postId)));
+        UserEntity userEntity = getUserOrException(userName);
+        PostEntity postEntity = getPostOrException(postId);
 
         // checkd liked -> throw
         likeEntityRepository.findByUserAndPost(userEntity, postEntity).ifPresent(it -> {
@@ -102,12 +97,43 @@ public class PostService {
 
     public int likeCount(Integer postId) {
 
-        PostEntity postEntity = postEntityRepository.findById(postId).orElseThrow(() ->
-                new SnsApplicationException(ErrorCode.POST_NOT_FOUND, String.format("%s not founded", postId)));
+        PostEntity postEntity = getPostOrException(postId);
 
 //        List<LikeEntity> likeEntities = likeEntityRepository.findAllByPost(postEntity);
 //        return likeEntities.size();
 
         return likeEntityRepository.countByPost(postEntity);
     }
+
+    @Transactional
+    public void comment(Integer postId, String comment, String userName) {
+
+        UserEntity userEntity = getUserOrException(userName);
+        PostEntity postEntity = getPostOrException(postId);
+
+        // comment save
+        commentEntityRepository.save(CommentEntity.of(userEntity, postEntity, comment));
+
+    }
+
+    public Page<Comment> getComments(Integer postId, Pageable pageable) {
+        PostEntity postEntity = getPostOrException(postId);
+
+        return commentEntityRepository.findAllByPost(postEntity, pageable).map(Comment::fromEntity);
+    }
+
+    // user exist
+    private UserEntity getUserOrException(String userName) {
+        return userEntityRepository.findByUserName(userName).orElseThrow(() ->
+                new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded", userName)));
+    }
+
+
+    // post exist
+    private PostEntity getPostOrException(Integer postId) {
+
+        return postEntityRepository.findById(postId).orElseThrow(() ->
+                new SnsApplicationException(ErrorCode.POST_NOT_FOUND, String.format("%s not founded", postId)));
+    }
+
 }


### PR DESCRIPTION
댓글 기능 테스트 작성 및 기능을 구현해보았다.

어떤 포스트에 댓글을 작성하고, 어떤 유저가 작성하였는지 알 수 있도록 CommentEntity에
PostEntity, UserEntity 를 **조인 컬럼**으로 설정하였다.

또한, 서비스단에서 중복되어 사용되는 Repository 호출 코드를 메소드를 호출하는 방식으로 리팩토링하여
코드의 중복을 줄였다.