### PR TITLE
#11 - 알람 기능 테스트 작성 및 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.vladmihalcea:hibernate-types-52:2.17.3'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 
@@ -58,8 +60,8 @@ task cleanFrontEnd(type: Delete) {
 	delete "$projectDir/front-end/static", "$projectDir/front-end/node_modules"
 }
 
-npmBuild.dependsOn npmInstall
-copyFrontEnd.dependsOn npmBuild
-compileJava.dependsOn copyFrontEnd
-
-clean.dependsOn cleanFrontEnd
+//npmBuild.dependsOn npmInstall
+//copyFrontEnd.dependsOn npmBuild
+//compileJava.dependsOn copyFrontEnd
+//
+//clean.dependsOn cleanFrontEnd

--- a/src/main/java/com/fastcampus/fcsns/controller/UserController.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/UserController.java
@@ -2,16 +2,18 @@ package com.fastcampus.fcsns.controller;
 
 import com.fastcampus.fcsns.controller.request.UserJoinRequest;
 import com.fastcampus.fcsns.controller.request.UserLoginRequest;
+import com.fastcampus.fcsns.controller.response.AlarmResponse;
 import com.fastcampus.fcsns.controller.response.Response;
 import com.fastcampus.fcsns.controller.response.UserJoinResponse;
 import com.fastcampus.fcsns.controller.response.UserLoginResponse;
 import com.fastcampus.fcsns.model.User;
 import com.fastcampus.fcsns.service.UserService;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -34,5 +36,12 @@ public class UserController {
         String token = userService.login(request.getName(), request.getPassword());
 
         return Response.success(new UserLoginResponse(token));
+    }
+
+    @GetMapping("/alarm")
+    public Response<Page<AlarmResponse>> alarm(Authentication authentication, Pageable pageable) {
+
+        return Response.success(userService.alarmList(authentication.getName(), pageable).map(AlarmResponse::fromAlarm));
+
     }
 }

--- a/src/main/java/com/fastcampus/fcsns/controller/response/AlarmResponse.java
+++ b/src/main/java/com/fastcampus/fcsns/controller/response/AlarmResponse.java
@@ -1,0 +1,39 @@
+package com.fastcampus.fcsns.controller.response;
+
+import com.fastcampus.fcsns.model.Alarm;
+import com.fastcampus.fcsns.model.AlarmArgs;
+import com.fastcampus.fcsns.model.AlarmType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+@Getter
+@AllArgsConstructor
+public class AlarmResponse {
+    private Integer id;
+
+    private AlarmType type;
+
+    private AlarmArgs args;
+
+    private String text;
+
+    private Timestamp registeredAt;
+
+    private Timestamp updatedAt;
+
+    private Timestamp deletedAt;
+
+    public static AlarmResponse fromAlarm(Alarm alarm) {
+        return new AlarmResponse(
+                alarm.getId(),
+                alarm.getType(),
+                alarm.getArgs(),
+                alarm.getType().getAlarmText(),
+                alarm.getRegisteredAt(),
+                alarm.getUpdatedAt(),
+                alarm.getDeletedAt()
+        );
+    }
+}

--- a/src/main/java/com/fastcampus/fcsns/model/Alarm.java
+++ b/src/main/java/com/fastcampus/fcsns/model/Alarm.java
@@ -1,0 +1,37 @@
+package com.fastcampus.fcsns.model;
+
+import com.fastcampus.fcsns.model.entity.AlarmEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+@Getter
+@AllArgsConstructor
+public class Alarm {
+    private Integer id;
+
+    private User user;
+
+    private AlarmType type;
+
+    private AlarmArgs args;
+
+    private Timestamp registeredAt;
+
+    private Timestamp updatedAt;
+
+    private Timestamp deletedAt;
+
+    public static Alarm fromEntity(AlarmEntity entity) {
+        return new Alarm(
+                entity.getId(),
+                User.fromEntity(entity.getUser()),
+                entity.getAlarmType(),
+                entity.getArgs(),
+                entity.getRegisteredAt(),
+                entity.getUpdatedAt(),
+                entity.getDeletedAt()
+        );
+    }
+}

--- a/src/main/java/com/fastcampus/fcsns/model/AlarmArgs.java
+++ b/src/main/java/com/fastcampus/fcsns/model/AlarmArgs.java
@@ -1,0 +1,13 @@
+package com.fastcampus.fcsns.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AlarmArgs {
+
+    private Integer fromUserId;
+    private Integer targetId;
+
+}

--- a/src/main/java/com/fastcampus/fcsns/model/AlarmType.java
+++ b/src/main/java/com/fastcampus/fcsns/model/AlarmType.java
@@ -1,0 +1,15 @@
+package com.fastcampus.fcsns.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AlarmType {
+
+    NEW_COMMENT_ON_POST("new comment!"),
+    NEW_LIKE_ON_POST("new like!");
+
+    private final String alarmText;
+
+}

--- a/src/main/java/com/fastcampus/fcsns/model/entity/AlarmEntity.java
+++ b/src/main/java/com/fastcampus/fcsns/model/entity/AlarmEntity.java
@@ -1,0 +1,66 @@
+package com.fastcampus.fcsns.model.entity;
+
+import com.fastcampus.fcsns.model.AlarmArgs;
+import com.fastcampus.fcsns.model.AlarmType;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+import java.time.Instant;
+
+@Getter
+@Setter
+@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
+@Where(clause = "deleted_at is null")
+@SQLDelete(sql = "UPDATE \"alarm\" SET deleted_at = now() WHERE id = ?")
+@Table(name = "\"alarm\"", indexes = {
+        @Index(name = "user_id_idx", columnList = "user_id")
+})
+@Entity
+public class AlarmEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    @Enumerated(EnumType.STRING)
+    private AlarmType alarmType;
+
+    @Type(type = "jsonb")
+    @Column(columnDefinition = "json")
+    private AlarmArgs args;
+
+    @Column(name = "registered_at")
+    private Timestamp registeredAt;
+
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
+
+    @Column(name = "deleted_at")
+    private Timestamp deletedAt;
+
+    @PrePersist
+    void registeredAt() { this.registeredAt = Timestamp.from(Instant.now()); }
+
+    @PreUpdate
+    void updatedAt() { this.updatedAt = Timestamp.from(Instant.now()); }
+
+    public static AlarmEntity of(UserEntity user, AlarmType type, AlarmArgs args) {
+        AlarmEntity entity = new AlarmEntity();
+        entity.setUser(user);
+        entity.setAlarmType(type);
+        entity.setArgs(args);
+
+        return entity;
+    }
+}

--- a/src/main/java/com/fastcampus/fcsns/repository/AlarmEntityRepository.java
+++ b/src/main/java/com/fastcampus/fcsns/repository/AlarmEntityRepository.java
@@ -1,0 +1,14 @@
+package com.fastcampus.fcsns.repository;
+
+import com.fastcampus.fcsns.model.entity.AlarmEntity;
+import com.fastcampus.fcsns.model.entity.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AlarmEntityRepository extends JpaRepository<AlarmEntity, Integer> {
+
+    Page<AlarmEntity> findAllByUser(UserEntity user, Pageable pageable);
+}

--- a/src/main/java/com/fastcampus/fcsns/service/PostService.java
+++ b/src/main/java/com/fastcampus/fcsns/service/PostService.java
@@ -2,16 +2,12 @@ package com.fastcampus.fcsns.service;
 
 import com.fastcampus.fcsns.exception.ErrorCode;
 import com.fastcampus.fcsns.exception.SnsApplicationException;
+import com.fastcampus.fcsns.model.AlarmArgs;
+import com.fastcampus.fcsns.model.AlarmType;
 import com.fastcampus.fcsns.model.Comment;
 import com.fastcampus.fcsns.model.Post;
-import com.fastcampus.fcsns.model.entity.CommentEntity;
-import com.fastcampus.fcsns.model.entity.LikeEntity;
-import com.fastcampus.fcsns.model.entity.PostEntity;
-import com.fastcampus.fcsns.model.entity.UserEntity;
-import com.fastcampus.fcsns.repository.CommentEntityRepository;
-import com.fastcampus.fcsns.repository.LikeEntityRepository;
-import com.fastcampus.fcsns.repository.PostEntityRepository;
-import com.fastcampus.fcsns.repository.UserEntityRepository;
+import com.fastcampus.fcsns.model.entity.*;
+import com.fastcampus.fcsns.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,6 +25,8 @@ public class PostService {
     private final PostEntityRepository postEntityRepository;
     private final LikeEntityRepository likeEntityRepository;
     private final CommentEntityRepository commentEntityRepository;
+
+    private final AlarmEntityRepository alarmEntityRepository;
 
     @Transactional
     public void create(String title, String body, String userName) {
@@ -93,6 +91,8 @@ public class PostService {
         // save
         likeEntityRepository.save(LikeEntity.of(userEntity, postEntity));
 
+        alarmEntityRepository.save(AlarmEntity.of(postEntity.getUser(), AlarmType.NEW_LIKE_ON_POST, new AlarmArgs(userEntity.getId(), postEntity.getId())));
+
     }
 
     public int likeCount(Integer postId) {
@@ -113,6 +113,8 @@ public class PostService {
 
         // comment save
         commentEntityRepository.save(CommentEntity.of(userEntity, postEntity, comment));
+
+        alarmEntityRepository.save(AlarmEntity.of(postEntity.getUser(), AlarmType.NEW_COMMENT_ON_POST, new AlarmArgs(userEntity.getId(), postEntity.getId())));
 
     }
 

--- a/src/main/java/com/fastcampus/fcsns/service/UserService.java
+++ b/src/main/java/com/fastcampus/fcsns/service/UserService.java
@@ -2,12 +2,16 @@ package com.fastcampus.fcsns.service;
 
 import com.fastcampus.fcsns.exception.ErrorCode;
 import com.fastcampus.fcsns.exception.SnsApplicationException;
+import com.fastcampus.fcsns.model.Alarm;
 import com.fastcampus.fcsns.model.User;
 import com.fastcampus.fcsns.model.entity.UserEntity;
+import com.fastcampus.fcsns.repository.AlarmEntityRepository;
 import com.fastcampus.fcsns.repository.UserEntityRepository;
 import com.fastcampus.fcsns.util.JwtTokenUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserEntityRepository userEntityRepository;
+
+    private final AlarmEntityRepository alarmEntityRepository;
+
     private final BCryptPasswordEncoder encoder;
 
     @Value("${jwt.secret-key}")
@@ -57,5 +64,13 @@ public class UserService {
         String token = JwtTokenUtils.generateToken(userName, secretKey, expiredTimeMs);
 
         return token;
+    }
+
+    public Page<Alarm> alarmList(String userName, Pageable pageable) {
+        UserEntity userEntity = userEntityRepository.findByUserName(userName).orElseThrow(() ->
+                new SnsApplicationException(ErrorCode.USER_NOT_FOUND, String.format("%s not founded", userName)));
+
+        return alarmEntityRepository.findAllByUser(userEntity, pageable).map(Alarm::fromEntity);
+
     }
 }

--- a/src/test/java/com/fastcampus/fcsns/controller/UserControllerTest.java
+++ b/src/test/java/com/fastcampus/fcsns/controller/UserControllerTest.java
@@ -12,11 +12,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -121,5 +127,33 @@ public class UserControllerTest {
                 .andExpect(status().isUnauthorized());
     }
 
+    @Test
+    @WithMockUser
+    public void 알람기능() throws Exception {
+        // Given
+        String userName = "userName";
+        Pageable pageable = mock(Pageable.class);
+        // When & Then
+        when(userService.alarmList(userName, pageable)).thenReturn(Page.empty());
+        mvc.perform(get("/api/v1/users/alarm")
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithAnonymousUser
+    public void 알람리스트요청시_로그인하지않은경우_에러반환() throws Exception {
+        // Given
+        String userName = "userName";
+        Pageable pageable = mock(Pageable.class);
+
+        // When & Then
+        when(userService.alarmList(any(), pageable)).thenReturn(Page.empty());
+        mvc.perform(get("/api/v1/users/alarm")
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
 
 }

--- a/src/test/java/com/fastcampus/fcsns/service/UserServiceTest.java
+++ b/src/test/java/com/fastcampus/fcsns/service/UserServiceTest.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import java.util.Optional;
 


### PR DESCRIPTION
알람 기능 테스트를 작성하고 그에 따라 구현해보았다.

알람 엔티티를 작성할 때, 'AlarmArgs' 라는 필드를 선언하였는데
이는 어떤 유저가 이벤트(댓글, 좋아요)를 발생시켰는지 그리고 이벤트의 발생지는 어디인지 알 수 있도록 필드를 선언하였다.
이 필드는 앞으로 확장될 가능성이 많으므로 DB에서 유연하게 확장 데이터를 받을 수 있도록 컬럼에 'jsonb' 타입을 사용하여
한 컬럼에 'jsonb' 타입으로 받을 수 있도록 타입을 지정하였다.